### PR TITLE
Pre-prod.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .current
-*.txt
 *.json
 *.swp
 *.log

--- a/cards.txt
+++ b/cards.txt
@@ -1,0 +1,600 @@
+1	Hello and welcome to CTFO, a new, 100% anonymous place for relationship advice. You're an expert, right? Good. Swipe this card to the right.
+2	By swiping to the right, you're advising the author to Chill The F*ck Out. The left swipe says That's F*cked Up. Swipe up to skip the card.
+3	Also, you can recall the last card by swiping down. Try it now!
+4	You can star the cards you like, report bad ones, and of course make your own. You'll discover the rest as you go.
+5	That's it for a quick intro. Make sure to star this card now so that you can come back to it later: its comments work as the app's FAQ.  
+I bought tickets to a show for my GF and me, and gave them to my GF to keep. After we had an argument she told me she had already invited her brother instead.
+Girlfriend becoming more and more religious, wants to stop having sex until marriage. We've been having sex for 1.5 years
+My wife lied about everything before we were married. I recently found out and my whole world is crashing down.
+My girlfriend screams as loud as she can to relieve her stress. I'm afraid the cops are going to get called on me 
+I have had the same FB for about 2 1/2 years now. I don't know his last name and don't know how to ask after this long
+Found out I'm pregnant with my ex's baby. I told him and he's not sure he wants me to have it. 
+I want to go away for a weekend with my BF but he told me that he doesn't think we're ready to travel together.
+The guy I'm dating has a small penis and I don't know what to do
+I am pretty sure that my wife's sister and best friend are on a quest to get rid of me.
+My BF and I have been together 8 months now. I am 38 and he is 40. Sex was daily. Now not so frequent. My self esteem is pretty low over this. He says it isn't  me, but what else am I to think.
+My husband is avoiding sex and would rather masturbate every morning
+My boyfriend will not let me look at his phone, ever. When texts go off, he makes sure I can't see who it is.
+My boyfriend is a pretty good one in most regards, but he is addicted to his iPhone. It's never off his person, whether in a pocket or in his hand. He checks it constantly, I feel like I need to fight for attention.
+My BF didn't accept my FB friend request. Isn't that weird?
+My boyfriend comments on other girls photos on Facebook saying how beautiful and good they look. He likes them too. Is this normal? I am upset and jealous? 
+Whenever I talk to my boyfriend of many years about planning our future life together his answer is always the same: "You know that I love you and we already share everything so what more do you need?" but I want commitment
+Is it ok for me (F/18) to spend the night with my boyfriend on the weekends? It's not about sex, it's just about being near each other, since we don't have a lot of time to give each other during the week, since we both work full time.
+My boyfriend wants to move in with a female friend and her mom. He says it's platonic, but I don't like it.
+My boyfriend went to dinner at Hooters with a few of his male colleagues, and I am really upset.
+My GF spent the night with an old friend - who's a guy. She said that nothing happened, and that he's like a brother to her, but I don't believe her.
+My BF kissed another girl at a party. I was really upset, but he said that he was drunk and that it didn't mean anything. 
+My wife always goes out shopping with her friends and comes back with new clothes. I tell her that we don't have the money, and she says she won't do it again, but then she does.
+I found women's underwear in my BF's drawer. He said it was from his ex-girlfriends & didn't mean anything.
+Whenever I talk with a guy, my BF get's really angry with me. I am not flirting, I'm just being friendly!  He makes me feel suffocated. I am fed up with this! 
+My GF says that she needs to take a few months off from our relationship to "find herself" but she wants to come back later. I say this means she is breaking up with me. Should I chill? 
+My wife would not have anal sex with me but I say that she really should not be so prissy about it. It is her duty to obey and please the husband after all. Who does she think she is?  TFU, no?
+My bf wants to do molly every single fucking weekend. I say once a year maybe. Twice. He knows that I might leave him but cannot stop. Should I CTFO?
+My gf drinks at least 4-5 drinks every single night. I am trying to get her to stop but she says I am controlling. Should I CTFO?
+My GF has a glass of wine daily and often 2-3 on Saturday night. I think she is becoming an alcoholic but she tells me I am insane. Should I CTFO?
+My GF accepted a new job without consulting with me. It pays more and it is closer to home and I have nothing against it but shouldn't he ask me first? Should I CTFO?
+My BF took a new job across the fucking country w/o asking me. It pays a lot more but it's 2000 miles away and now we have a long-distance thing. Is it over? Should I CTFO?
+My wife has coffee with male friends all the time but gets angry if I have a drink with a woman. I am mad that she gets upset, but she says that it just different.
+GF wants to do everything together and is upset when I have a poker night with other male friends. She says that I can't do it no more than once a month. WTF?!?
+My BF says that he is not gay but I keep catching him watching gay porn. I am afraid that he is in the closet and will eventually leave me. 
+My husband says that he does not like men but dresses like a total homosexual. He is into the whole steampunk scene, suspenders and shit. I think he is in fact a homosexual and will dump me one day. I am really worried!
+I have been dating a divorced man for a year and he is yet to introduce me to his two children, 7 and 9. I am feeling that this is not normal if he really wants to be with me long-term.
+I [M/55] am in love - she's a lot younger than me [F/21]. She is happy to see me but always wants me to buy her stuff. Not just clothes, but a car, pay for her college tuition etc. 
+My GF and her ex have a pet in common. I am really upset about this and demanded that she dumps the dog. 
+My boyfriend always talks about his old GFs, and he is always being charming when my hot friends are around. I love him, but WTF?
+My girlfriend's new boss is a woman, and she talks a lot about her all the time. Not only business stuff, but nail polish and heels too. I don't think that's OK.
+My gay friend keeps hugging my girlfriend every time they meet. Last time he slapped her bottom. She seemed to like it. What should I do?
+I wear short skirts, and no one says anything. But one time I show up in tall boots and now people call me a slut!?!?
+We spend fifteen minutes arguing about the brand of condoms and ended up not having sex that night. How do I tell him I don't like fruit scents?
+My co-worker forgot her wallet and I paid for her. It was no big deal until she handed me the cash in front of everyone in the office, smiling and saying "It was great". I'm worried everyone thinks there's something between us.
+I cheated on my boyfriend. He keeps telling me that we are meant for each other, and that it was a one night stand, and it didn't mean anything. I'm not even sure.
+Okay gals. A week of pineapple juice diet. Gluten-free too. Still salty. She hates it & won't swallow. 
+My boyfriend says he deserves someone more attractive than I am
+I have to pick between my dream job - I would make 5x what I make now!  But I have to move. I want my GF to give the long distance thing a chance, but she says no. 
+I want my daughter to marry a doctor but show won't leave this other guy.
+A teacher called my 13 year old daughter a prostitute
+I love my boyfriend, and he loves me, but I know he doesn't think I am beautiful
+My GF just texted me "I need some space"
+The love of my life just told me that my breasts are small and I need to work on them
+A stranger just called me ugly
+My GF used to kiss anyone at parties, and when we started dating, she stopped going. Now she wants to go to parties again
+My BF brought me to a basketball game and then dumped me at the end. He told me it was because he didn't want to miss the game
+When the moment finally came things only last for literally 10 seconds. So when he got up I asked him, "What's wrong? Why are you stopping?" He just made up an excuse of how the condom broke and he didn't have another one.
+My husband is chatting with cam girls, daily
+My BF cancelled on me AGAIN. I'm so tired of having my dates cancelled for fantasy football!
+My husband is so messy that I slipped on something he left on the floor, crashed into the furniture, and broke my toe. He said I should have been more careful!
+My BF has a female friend who doesn't like me. He says it's my job to get her to like me. She yelled at me in my own home.
+My mom broke my dad's heart. And my stepdad's heart. And another stepdad's heart. Now she wants me to be her bridesmaid in her fourth wedding and I don't want to do it.
+My GF forgot my birthday. She said she got me a gift, and she only forgot because she had to work late, but I think that's BS
+My ex husband cheated on me and then tried to sue me for alimony. He wants to be friends, but I say no fucking way. 
+My boss sent a large group email saying that I was wrong about something but I wasn't. He won't apologize. 
+My friend had another fight with her BF - it's the same story over and over. I am getting sick of her crying when she does it to herself. She's driving me crazy!
+My BF's best friend has been hitting on me, and grabbing my butt. My boyfriend does not believe me!
+I told my BF that I like roses and candy on Valentine's Day, but he just got me a card. I'm going to break up with him.
+My GF is a gynecologist, as are many of her friends. When we go out they all talk about is "work" and I'm embarrassed because they don't keep their voices down!  
+My BF doesn't shower every day. He plays a lot of sports and I told him it's disgusting and he can't get into bed with me until he cleans up.
+My GF just asked me "why do you have such a small one" in front of my friends!
+My BF plays poker with the guys every week. He tells me no girls are allowed, but I heard one of the other guys tell a story of a girl who came wearing just lingerie for his birthday 
+I like this girl, but she keeps cancelling on me. She's really nice about it, but I think she doesn't want to date me.
+My boyfriend just became a vegan. I love steak. Im not sure we have a future.
+My BF knows the lyrics to every Kylie Minogue song, but he says he's straight. Should I end it?
+My GF wants to have implants so she can have a butt like Kim Kardashian. I say that's totally messed up.
+My GF thinks I look like Anthony Hopkins. Should I be insulted?
+My GF has watched every Clint Eastwood movie there ever was. I can't stand Clint Eastwood.
+My GF won't watch any football games with me.
+I came home last night to find my BF wearing my rubber dress. I'm not sure what to think.
+I found high heels in my BF's closet. They fit him.
+My BF wore my underwear to work today.
+My GF grunts during sex. It grosses me out.
+My partner won't help with any household chores. I tried talking to him about it, he said I should be doing it since I'm the one that cares about things being so clean.
+My boss and I are in love he says I should look for a different job so we can date. He says he would have resigned but  he has a better position in the company and it will be easier for me to find a new entry level job somewhere else.
+I am dating a 29 single man who irons his cotton t shirts.... Is this a red flag? 
+My BF stayed out all night at least three times a month for the last 7 months or so. When I asked him where he is, he says he got drunk and fell asleep at a friends house
+My girlfriend follows this guy that likes her on Instagram but won't let me see any of his pictures. Should I be worried?
+I am 32, married to a great guy. I go out with the same coworker (M44) for lunch every day. We get along really well and love spending time together. I don't think it is romantic but I still feel bad telling my husband.
+He said he loved me and asked to be with me. Then one week later, he tells me he's leaving the country for a job
+I flirt with other men and my boyfriend says he is not jealous. I like the freedom but it really bothers me that he does not care
+My boyfriend was flirting with other women a lot when we started dating. He says he does not do it anymore but I find it hard to trust him
+My BF wanted to have sex with me and another girl. I said OK. Now he wants to have a big orgy. 
+My husband told me that he does not want to have sex more than once a week. It distracts him from his work.
+My boyfriend hates kissing and cuddling. He says he loves me, but he just doesn't like to touch so much.
+My girlfriend hugs other men all the time. She says she is just being friendly but I think she's flirting. it really bothers me
+My boyfriend will not show me any pictures of his ex girlfriends
+My boyfriend is taking classes with my best friend and they are always studying together. I am feel left out 
+My best friend slept with my brother.
+I had six dates with a guy and I like him. He gives me compliments and texts me a lot but didn't touch me yet. I am not sure what to think
+My boyfriend never washes his hands after he goes to the bathroom. 
+My co-worker blames me for problems even when it is her fault. I feel bad calling her a liar, but I am angry at her!
+My BF is really nice to me, but he dresses like a slob, and I am embarrassed to be seen with him.
+My mom grounded me for two weeks for making her wait five minutes when she was picking me up at my friend's place. I think that's totally unfair.
+I (24/F) want to move in with my BF (26), but my mom is guilt tripping me, and says that I'm too young and that she can't live without me.
+I just found out that my GF had sex with three different guys at her work before we got together. I can't stand that she goes there and sees them every day!
+I was playing poker with friends, and my best friend got really upset because I lied to him about my cards. I said that's what poker is all about!  Shouldn't he CTFO?
+My friend borrowed $1000 from me, and hasn't paid me back. Now he says that if I am really good friends with him, I'll lend him another $1000. I told him to fuck off.
+My best friend is dating my ex-BF. I told her that's just not OK, but she says I'm not dating him anymore, so he's fair game.
+My boyfriend asked me if my last BF was really big, because I'm so loose. I'm so fucking mad at him!
+My BF told me I wasn't so good in bed. He's the first guy I slept with!
+I'm a guy and I have a friend who's a guy who always slaps my ass like it's a joke, but I hate it & I think maybe he's gay 
+My mom's new BF "accidentally" left his phone in the bathroom when I was in there!
+I caught my step dad in my room with my underwear drawer open. He said he was just cleaning the room up.
+My wife likes to go to bed much later than me. No matter how late it is, she doesn't want to come to bed until I am asleep.
+My GF gets up every morning at 5:30 to go jogging. She wakes me up every time.
+My wife spends all day shopping online, and then I come home and the house is still dirty and she didn't cook anything for dinner
+My wife spanks our son when he misbehaves. I don't think that's OK, but she says her dad spanked her and she came out just fine.
+My BF (35) was making jokes about picking up girls at the high school. 
+My BF (25) was making jokes about picking up girls at the high school.
+I can't get my GF to have an orgasm. She says it's not me.
+My GF needs to use a vibrator when we're having sex. She says it's normal to need that.
+My BF uses a cock ring because he says he can't stay hard otherwise. 
+My BF wants me to dress slutty because it turns him on. I think it's dirty.
+My GF wants me to role play in bed, but I worry it means she wants to have sex with someone else.
+My BF (22) gets mad if we don't have sex at least once a day. 
+My BF only wants to have sex maybe once every week.
+My BF is so selfish. Once he's done in bed, he won't touch me and just leaves me alone.
+I was living at home. Then I moved in with my GF who lives three towns away, and my mom moved to the same town to be near me.
+When it snows, my husband shovels his mom's driveway first.
+My wife (26) talks to her mother like three or four times a day and for a long time each call
+My wife is always cleaning up my shit and I can never find it
+My friend borrowed my car and put a dent in the fender, but says that it's no big deal because my car was a piece of crap anyway
+My friend borrowed my favorite book - a book my mom gave me when I was a kid - and then lost it. He got me a replacement, but it's not the one my mom got me.
+My GF told me that she won't give me back the hat I left at her place unless I make her dinner
+My husband keeps using my toothbrush. It's absolutely disgusting!
+My wife comes home late, eats dinner, watches TV, and goes to sleep. She never 
+compliments my cooking. I just want to feel appreciated.
+I think my BF and my mother are attracted to each other. They laugh and joke together when he comes over.
+My BF has disgusting feet from playing so many sports. If he doesn't get a pedicure soon I'm going to lose my mind. It's like he has Hobbit feet.
+I just found out that my GF of three years didn't know my name when we first slept together. To find it out, she went to the bathroom and looked at my prescription bottles.
+My friends think that I'm superficial because I break up with men for small things. I really like my current boyfriend but he smacks when he chews so I am thinking about breaking up. 
+I'm so in love with this girl. I keep calling and texting her but she doesn't get back to me. I'm thinking about driving by her house or surprising her at work.
+My BF keeps posting our relationship problems on this website. I wish he'd talk to me instead!
+My husband is obsessed with football. I hardly get any attention during the season. I once walked naked in front of a game and he asked me to move out of the way.
+I went to University of Georgia. My fiance went to University of Tennessee. Our families don't want us to be together because our alma maters are SEC rivals and we are both legacies. 
+My BF never washes his hands
+My wife does not want to go to Burning Man and does not want me to go without her
+My mother hates my boyfriend. She's usually right about these things, but I love him. Chill or take her advice?
+I'm dating two people that I work with and I'm worried that if they find out, this will all blow up on me. Chill or not?
+My boss keeps hitting on me. He's cute and all, but I'm married. I can't tell if it's just playful banter. Should I just relax?
+My boyfriend spends more time playing sports than with me. If I want to spend time with him I have to go see him play.
+I'm lactose intolerant but my husband keeps only buying regular milk. I kind of want to throw up on him the next time I'm sick from it, just to prove a point.
+My friend owes me money but has been avoiding me. I really wish she'd just pony up so I don't have to make it weird to get my cash back.
+I'm sick and tired of my husband leaving his dirty clothes RIGHT BESIDE the hamper. 
+I had to tell my boyfriend that I wouldn't see him anymore if he didn't shower more. I told him nicely but now he's mad at me, and he's still unclean!  
+I have a dog but my girlfriend is allergic. I don't want to have to give up either one of them!
+If my girlfriend is trustworthy, she'll give me the passwords to her email and Facebook and Twitter accounts, right?
+I just found a snapchat app on my husband's phone. That means he's cheating on me right?
+My girlfriend is a bartender and flirts while at work. She says that it's to increase tips but I don't know if I should believe her.
+I think I met the woman for me last week. We slept together on the first date but I haven't heard from her since. I'm thinking about calling or texting, or maybe going to her house or work to surprise her.
+My girlfriend can't handle heavy moments and ruins them with jokes!  The jokes are really funny but I'd like to make some emotional progress.
+If my girlfriend of 3 years doesn't put a ring on it soon, I'm outta here.
+I'm in an open relationship. It works well most of the time but sometimes my wife doesn't make enough time for me because she's out with other men.
+I think my sister is too strict with her kids. 
+I'm feeling like a bad mom. I let my kid have Cheetos for breakfast so I could sleep a little more.
+My girlfriend sets several alarms because she turns them off in her sleep. But they wake ME up!  
+I just found out the man I'm dating is 18, and I'm 40. I hope he has at least graduated high school. :(
+I think my husband has been reading my journal. I feel violated!
+My sister didn't invite me to her birthday party.
+My mother gave away my unicycle because she said I didn't ride it much.
+My roommate never does the dishes
+I ask my BF to take out the trash, and he never wants to do it
+My mother sometimes borrows my outfits to go out. She says it's only fair because she helped me pay for them. But they're mine!!
+My boss won't let me go on vacation for six months, even though we discussed this before and he told me it was OK.
+People are spreading rumors that I'm dating someone at the office, and it's not true
+My boss won't let me leave work three hours early to go to a playoff game. It won't affect my ability to hit my deadlines, but he says no, because it looks bad.
+My GF thinks my hair cut looks bad and she wants me to cut it, but this is the way it's been for years.
+My sister takes clothes from my closet and says they are hers
+My friend borrowed by lawn mower & hasn't given it back. It's been a year.
+My best friend negotiated with a neighbor to sew her prom dress for $100. My friend never paid, and the neighbor is too polite to ask for the money. I think that's just not OK
+My teacher knocked two grades off my final project because it was late, but my dad was in the hospital for a heart attack.
+My BF is always starting at other women when we are walking around. It really makes me feel bad.
+A guy asked me out to dinner, but then expected me to pay
+This guy asked me out to dinner and when the bill came, he expected us to split it!
+My BF has multiple toothbrushes at his place but he lives by himself.
+My BF likes to knit - seriously! I think he might be gay.
+My partner won't allow me to hang out with my friends. He says they're not good for me.
+My BF won't go to church with me, even though he knows how important it is to me
+My GF says I have to convert to Judaism before we get married. I love her, but isn't that a little too much?
+My BF and I (F/32) have been dating for 5 years, and he's still not ready to get married
+My GF is Catholic and she says we can't get married because I'm Episcopalian. I'm not even that religious and I don't think it matters
+I've been working hard at my job for more than three years, and still no raise
+My roommate's cat pukes on the carpet and it takes him days to clean it up. That's so gross!
+I joined this cool group of people & I have lots of fun with them, but my BF says it's a cult and he won't let me see them
+My mum grounded me for not doing the dishes last night. I just forgot.
+My dad makes me give him my iPhone when I get home from school until my homework is done, and then takes it away when it's 10:00. I'm 16!
+My best friend stole my BF, and she said that he wasn't happy with me, and it's better for people to be with the person who's right for them.
+I asked my boss for two weeks off for my wedding & honeymoon six months in advance. Now my wedding is in three weeks, and he says it's crunch time and I can't have more than two days off
+I am dating this guy for a month, and now I haven't heard from him for more than a week, not even a text.
+It's my birthday and my best friend never said happy birthday to me
+My boyfriend plays his X-Box. He's over 40, for crissake.
+My girlfriend cried when I bought her red lingerie. She thinks it's only for sluts. I only want her to wear it long enough for me to tear it off anyway. 
+My wife keeps wearing socks to bed, even though I've told her a hundred times it's not sexy. WTF?
+My partner insists on talking about how smart he is every time he gets drunk. I'm too embarrassed to take him to work events.
+I can't take my husband to work events. He can't make conversation. He's wrecking my career.
+My wife resents that I work so much, but she doesn't have a job, and she buys more Manolos than Imelda Marcos ever did. I'm a corporate partner at a global law firm. What the hell does she expect?  
+After we had children, my wife/husband started talking baby-talk in bed. Eeeuuuw!
+My brother wore my shoes and now they stink
+I told my BF that I want to have The Talk, and now he is totally avoiding me.
+My boss hasn't let me take vacation for six months even though I have four weeks saved up
+My husband keeps promising me that he'll do the dishes, and then he doesn't. Now there's been a big pile of dishes in the sink for more than a week, and nothing.
+My BF keeps wearing shirts with stains on them. It's so unprofessional!
+My boss told me I am not dressed well enough (I am in sales). I just spent $2,000 on my wardrobe. Isn't that enough?
+My sister keeps sneaking into my room and stealing my clothes and then putting them back dirty. I found a mustard stain on my favorite blouse!
+My GF was flirting with this guy and gave him her number right in front of me!
+My GF is always telling me her plans for revenge for all sort of things she thinks people have done to her. I am worried that it is only a matter of time until she starts targeting me.
+I am a waitress, and I have a regular customer who always under-tips me. I want to spill coffee on him!
+My professor is always calling on me and embarrassing me. I think he hates me.
+My coworker told me that I always wear shirts that are too bright. 
+My GF loves to go to Vegas, and she sometimes loses $1,000s. I am really worried.
+My BF plays poker with all his friends every week. He comes home at like 3:00 in the morning, and sometimes loses $50!!!
+My GF's colleague gave her perfume for her birthday. She says he's just being nice. I think there's something more going on.
+My friend didn't invite me to his birthday, and when I confronted him he claimed me it was a mistake, and that he meant to send me one.
+My husband has been coming home from work late, sometimes 9:00. He says he has to work late because of a product launch, but I think he just wants to spend time with a new manager there who has the hots for him.
+I think my BF loves his dog more than me!
+My friend borrowed $500, and now can't pay me back. I need the $$$
+I think my co-worker is stealing from the cash register. I feel like I should turn him in.
+My brother gets to borrow my dad's car, but then he won't pick me up from football practice.
+My boyfriend didn't get me flowers for V-day
+I think my boss is cheating on his wife with his secretary. I think his wife deserves to know.
+My co-worker is stealing sticky notes and taking them home
+My colleague is stealing all sorts of shit from work - batteries, pads of paper, soda, even toilet paper!
+My husband eats only fat free and low fat food. When he's cooking and not looking, I add oil and butter so I can tolerate dinner.
+My BF's family is totally dry, so when they come over he hides the liquor!
+My GF chews with her mouth open. It makes my skin crawl.
+My BF can't dance and doesn't know it. He embarrasses me when we are out.
+My BF bought me roses. Again. I hate roses and he knows it.
+My GF cracks her knuckles all the time. It's like nails on a chalkboard to me!
+My wife is a total neat freak. I can't find anything because the second I put it down, she's put it away.
+My BF keeps stealing my medications. He can afford his own, but he's too lazy to get his own stuff.
+My BF just will not turn the sound off on his phone. I keep getting woken up in the middle of the night for his emails and I want to choke him in his sleep.
+My BF is a nose picker. He thinks I don't see it but I do.
+My roommate keeps eating my food.
+My GF checks out other men when we are out together.
+My GF let another man buy her a drink at the bar and I'm furious.
+My wife wants to "open up" our relationship. I'm afraid she'll meet someone better than me!
+When I get home from work, I expect my husband to have dinner ready. Is that so much to ask?
+My guy friends keep hitting on me. Can't women and men just be friends?
+My ex won't leave me alone. He keeps calling, emailing, texting...I want to tell him to stay away but don't know how to do it nicely.
+My ex GF wants to be friends but I'm not sure I can move past all of the shitty things she did while we were together.
+I just found my GF using a vibrator. It makes me feel like I'm not good enough in bed.
+My BF keeps trying to introduce sex games into our lives. Is he bored already?
+My GF freaked out last night because I didn't want sex. I was really fucking tired.
+My BF is one of those guys who is always looking for more. More what?  I guess he wants to be single his whole life.
+I keep dating messed up women. Does this mean that I'm messed up?
+If my husband leaves the gas tank empty one.more.time. I'm going to lose my shit on him.
+My BF's BFF is getting married. I don't want him to go to a bachelor party where there are strippers. Am I being too controlling?
+I just don't understand vegetarians and I'm dating one. I wonder if I should end it.
+I am starved for sex in my relationship. I think too much damage has been done to ever fix it.
+I'm a sex addict, into swinging, hookers and more... Am I fucked?
+I have a boyfriend who opened up to me about his biggest secret, and I don't know how to comfort him.
+I don't know how to talk to my boyfriend about the next step in our relationship of six years.
+I know my girlfriend of almost years is using drugs but she keeps denying it
+I took my boyfriends livelihood away. I feel awful & in desperate need of advice.
+I'm breaking up with my ex because he's a racist. Is that a valid reason?
+I have a foot fetish, and I want to get rid of it.
+Did I fuck up my relationship with my fiance by messaging my ex during an argument?
+I'm getting heavily mixed signals from ex. I want to hook up with her.
+I not sure if there is any love left after four years with my wife. I think it's over
+I've been married for 5 years, I'm on the verge of Divorce... we have one kid, we both love him and we both want him.
+My  girlfriend is constantly calling me insecure when I tell her her obsession with Kit Harrington is annoying.
+I'm not sure if love my girlfriend and I'm scared.
+My husband is a dumbass.
+I am three days late, and I am super anxious
+I might lose my significant other to depression (not suicide). Anxiety tearing me apart...
+I moved out of my moms house but she keeps asking me for money!
+I'm a 27 year old virgin. What am I doing wrong?
+How do I tell my mother she needs to go back to work?
+My girlfriend is studying abroad in Paris for fall semester. I'm thinking it's time to take a break in the relationship.
+How do I tell my sister-in-law to watch her kids or discipline them?!
+My ex is giving me hopes of reconciliation and I am not sure how to proceed. Should I go for it?
+My husband and I don't have similar outlooks for the future. He wants to focus on his career and I want kids.
+I have feelings for my girlfriend's housemate. Is that bad?
+My girlfriend of five years is upset that my family wants to have a weekend vacation without her. Shouldn't she CTFO?
+We're on the verge of divorce after a 5-year relationship…. I won't give up without a fight!
+My crush was sexually assaulted and doesn't trust me.
+My GF wants me to move out of my house (I am currently living in with my mom) and live with her and her parents. I don't know if it's a good idea.
+I can't figure out why she vanished off the face of the earth. She won't call me back or text me.
+I fall so hard for every girl I meet.
+My older brother has been a selfish mean person to me and I've had enough. I'm not talking to him anymore.
+My anxious girlfriend has a hard time telling me what is bothering her.
+My girlfriend is going away to another country for a year and is leaving me behind.
+She lies to me, manipulates most situations, and hides things constantly because she doesn't want to fight.
+She won't reply to my texts!
+My mother just dumped water on my child's head as a punishment.
+I'm taking a break with my boyfriend. He says we should still communicate.
+Just got engaged, but I'm having cold feet & want to end the relationship.
+I broke up with boyfriend several weeks ago and struggling 
+My girlfriend didn't want me to come over until later because she was napping. WTF?
+My friend and I almost hooked up last night and now things are super awkward...
+I think my BF is in a toxic relationship. Should I tell her?
+I might be engaged to an addict and I'm worried.
+My girlfriend doesn't let me do anything without her.
+Not sure if I should stay or leave him.
+Lately when I talk to girls they bring up their boyfriend very early and frequently in conversation.
+Him: "I lack time for myself, career is more important than relationship, I can't give you as much attention as you want".
+My girlfriend of a year wants to stop hooking up.
+My friend uses me for blowjobs but I want it to be more...
+I don't trust my girlfriend anymore.
+I fell in love with another girl. Now I love two girls.
+I am having anxiety/codependency/alcohol-related issues with girlfriend.
+My boyfriend feels like he needs to be in charge of everything in our relationship.
+I have irrational lingering thoughts and feelings for someone I dated for a short period of time.
+I'm constantly having trust issues with partner.
+My boyfriend asked another girl out on a date and told her that things weren't great with me.
+My girlfriend wants to break up after we graduate.
+My girlfriend kissed another guy on the lips at a party.
+My girlfriend asked for a break.
+My roommate called me a bad person and said her other friends agree
+I want to tell my boyfriend that I love him after I told him not to say it to me
+I thought I was loved and now I wonder if this woman isn't seriously mentally ill.
+My best friend thinks that his girlfriend cheated on him with me. Should she CTFO?
+My girlfriend of a year and I are having some problems with attraction and other things.
+My girlfriend said she likes attention from other guys.
+I've been dating this girl for years and it keeps getting worse by the day.
+I think my boyfriend hates me. He always is hanging out with the guys playing video games.
+My girlfriend's parents are driving me crazy.
+I told my boyfriend my fetish but he seemed weirded out.
+My ex asked for more time to think about whether we should get back together… I need to know now!
+I love him. i'm scared to tell him.
+My boyfriend's sexuality, that of a fairly typical male, is so much different than mine, which is fairly conservative.
+My girlfriend stole my mom's car.
+My GF had a party, I was invited. Her friends called me by someone else's name the whole night.
+My double life is taking its toll, but I can't stop it.
+My friend wants to sleep with me.
+Why don't people like me?
+I'm not Interested in new girlfriend's kid.  I'm worried that's going to be a problem.
+Sometimes I think I sincerely love her and want her back, sometimes I just think it because my ego has taken a bruising during the breakup.
+I am considering to break up with my GF due to her job as a model.
+I am ashamed of my small genitals.
+I am ashamed of my floppy bits down there.
+I am ashamed that my nipples are too dark
+I am constantly arguing about how much we talk/see each other online.
+My girlfriend's was in an awful mood, and then she breaks up with me after I try and get her to talk to me about it. 
+I have this awkward relationship with a co-worker. He likes to hug me sometimes.
+I feel like everybody has someone... but not me.
+I Want To Get My Boyfriend Back! 
+I'm worried I'm not ready for another relationship yet, but I just started seeing someone new.
+I told his girlfriend he cheated on her with me, but she's still with him.
+My sister is in an abusive marriage. But her fear of her controlling, violent husband is the only thing holding her back from committing crimes that could ruin her life. Should I do something?
+I don't feel like a priority for my girlfriend.
+I'm wanting more effort/appreciation from my girlfriend of three months.
+There's a girl from work who I asked out and she probably doesn't want anything to do with me now.
+My husband lied to me.
+My girlfriend called me ignorant.
+I broke up with my girlfriend earlier this week and I don't know if it was the best decision.
+My girlfriend cheated on me but I still love her.
+My boyfriend wants to see me more often, but I prefer my space.
+I need more privacy with my boyfriend but parents are weird about the relationship.
+I want to tell my friend I have a crush on her before I leave America in a month
+I'm going through my first breakup and I don't know how to deal with this emotional pain...
+I'm constantly having sex dreams but not about my wife.
+I don't really want to be around my friend anymore, but he keeps calling to do stuff.
+My GF is so slow - it's been two months now & no action!  
+I'm a second time bride with a first time groom. He wants to control the wedding plans,
+I'm confused to choose between two people and I feel like I'm not a good person.
+I make coffee for a cute co-worker. My girlfriend threatens to end the relationship if I don't stop.
+My boyfriend of 3 months is not attracted to me.
+I am afraid to/can't break up with my girlfriend because of her mental health.
+I know I'm falling for him but I don't want to.
+I think I'm in love with my best friend.
+My libido died.
+I slept with my friend's girlfriend.
+My boyfriend freaked out when he found out I'm on an anti-anxiety med. Shouldn't he CTFO?
+I don't feel an emotional spark for my girlfriend. I think I might leave her?
+I am a very shy girl.
+I'm not sure if I should ask out my close friend. I'm getting somewhat mixed messages from her.
+I'm having thoughts about dumping my girlfriend and I don't know why!
+I have no social life & think I must be an awful person.
+I am really unsure about what to do in my relationship with my girlfriend.
+I was just left by my fiance this week. I want to jump off a bridge.
+I have to move for work; and my boyfriend of two years is afraid to come with me because he's a teacher.
+My boyfriend used to do gay porn.
+I recently started seeing a girl who just admitted to me she wasn't a virgin.
+I am worried to tell my mom I am a crossdresser?
+I always think that my boyfriend is cheating.
+The girl I fancy sends me photos of myself.
+My girlfriend hangs out with her exes and it makes me uncomfortable.  
+There's no hope.
+She might be the one, but I'm not sure because I've only had sex with two girls including her.
+I want to break up with my girlfriend due to her emotional issues?
+My boyfriend has cancer, and we want to get married. My mom says it's a really bad idea. Should she CTFO?
+My youth was complicated I had messed family relations & I don't think I should date anyone.
+I think my boyfriend is bi.
+I don't orgasm easily or at all and my boyfriend has become obsessed with this issue. Should he CTFO?
+My GF has a "guy best friend" that I don't want her to be friends with anymore but she won't stop talking to him.
+After ten years, I think my marriage with my wife might be falling apart because of money.
+My girlfriend doesnt give me any free time and threatens to break off the relationship because I'm not always there.
+My European girlfriend has lots of guy friends that she texts a lot and I find it hard to relax about. 
+I went on a date with a girl I met on campus and the following day she tells me she's going to another town to visit her boyfriend that she never mentioned before.
+I have been in a doomed relationship for years.
+I can't get out of the friendzone with a longtime friend who has a lot of platonic guy friends
+My GF has been "Off" for about a month. I think she's possibly attracted to other people.
+I don't understand how to interact with girls.
+I've never kissed anyone. I'm 23.
+I'm scared of my boyfriend who has anger issues.
+I feel that she is using me.
+I'm in love with one of my best friends , but he won't stop talking about her love/sex life.
+I'm scared to tell my S.O. that I started therapy
+I think my boyfriend is planning to leave me as soon as the semester ends. Either that, or I'm going crazy.
+I developed a crush on a childhood friend who lives on the other side of the world. Is that OK?
+I'm between different girls, and I don't know what to do!
+Girlfriend changed browsing history settings to spy on me.
+My new roommate's boyfriend comes over way too often.
+The love of my life catfished me...
+I am having privacy issues with my religious girlfriend.
+My girlfriend had an out of state fling and I suspect she is still communicating with him.
+I don't know what I want in life.
+I'm considering relocating after my ex passed away and I'm feeling guilty and confused.
+I am so friggin' awful at chatting with girls online.
+I broke up with boyfriend because of his intimate relationship with his best friend,
+My girlfriend is high maintenance and it's stressing me out.
+My boyfriend more sexually experienced than me. Is it right for me to feel insecure?
+My wife has been talking to an ex behind my back and it's gotten serious, but she has no clue I know.
+What's the deal with men and women who are on several different dating sites?
+I can't bring myself to tell the girl back home that I've had a crush on her for years?
+Found out ex girlfriend now has a kid. For some reason I can't stop thinking of her.
+My old GF moved away and a new girl is interested. My mind is still stuck on my old GF. I don't know if it's OK to date the new girl.
+Should I try to contact this girl that rejected me?
+My boyfriend wants to move to an apartment that is minutes away from his parents.
+I am having trouble finding common or deep topics to talk about with boyfriend.
+My family is falling apart since my Dad lost his job, and I'm at a loss.
+My boyfriend is great but he cries a lot and it turns me off.
+Every time I get into his office my husband quickly closes the window on his computer screen
+My BF wants to have an FMF threesome with me and his ex.
+I feel like guilty when I tell my boyfriend not tonight.
+This guy I'm dating disappears to the bathroom and comes back semi-aroused.
+My long term GF's friend does everything to break up our relationship and constantly tells my GF that she should leave me.
+My BF and I had been together for two years but his friends still keeps on introducing girls to him.
+My BF doesn't want to have a serious relationship but he says he loves me.
+I am dating a guy that washes his hands and wants me to wash mine before we touch each other. I think he is OCD about hygiene.
+My BF broke up with me but he keeps on calling and stopping at my house to check on me. We make love and he says that he still loves me but does not want to get back together
+My husband wants to go to parties every weekend. If I don't come he goes by himself.
+My girlfriend always talks about how other men flirt with her. I think she is trying to get me jealous but it just makes me feel like she is sending men wrong messages.
+My boyfriend (one year together) refuses to meet my parents.
+I spy on my girlfriend. I check her phone once in a while just to be sure I can trust her. I know it is wrong but I can't help it.
+I left my job and moved with my boyfriend to Denver because of his work and now that he is settled in the new place he wants me to move out.
+My girlfriend is sending other men hearts, winky faces, & other shit all the time. WTF, right?
+My boyfriend spends thousands of dollars a year on his clothes and tries to impress girls all the time.  He is obsessed with getting attention and charming everyone
+My husband thinks we can afford a new car for him but refuses to spend money on renovating our old kitchen or going on a family vacation. TFU, right?
+My GF always laughs hysterically after orgasm. 
+My husband is sexting with women I know, saying how much they turn him on and how he would make them come.  When I found out he said it is just words, and I should CTFO. 
+Every time my girlfriend is working on the computer and I get into the room she closes the window or moves quickly to another screen
+My 8 years old daughter hates my new boyfriend and gives him a hard time. I am really torn.
+My abusive ex-husband and my current boyfriend are becoming best friends. Last night they went out for a drink without me. 
+My professor didn't accept my final paper because my bike broke and I was ten minutes late to submit it.
+My best girlfriend invited my boyfriend to dinner at her place without me. She says that this is for me, she just wants to know him better
+My girlfriend is turning my best friend into her confidante.  She is sharing with him details about our fights
+I am attracted to my friend's mom. She is divorced and interested in me too. My friend thinks that it is fucked up. He should CTFO, right?
+My coworker is extremely judgmental. She has something critical to say about everything I say or do. 
+My wife shares with her mom all of our private conversations.
+I love my gf but I tried everything and cannot make her come. This never happened to me before. She says she stills enjoys sex but I am frustrated.
+I am so sick of being inexperienced that I just want to bury my discomfort with having sex with a random guy, is TFU or should I chill and wait for the right one?
+I know my girlfriend of 5 years loves me but she constantly says things like "after we will break up…" or "with my next boyfriend…"
+A guy in our group presents himself as a friend of both of us but he texts my wife every other day asking for advice and talking about his day and never contacts me. 
+My selfish husband wants us to move to a much smaller apartment next to his work.  It costs twice as much and the schools are bad. TFU, right?
+My mom is friending all of my close friends on Facebook.
+My parents always take my sister's side. 
+I want to switch rooms with my roommate. She had the bigger room for first 6 months of the lease and we pay the same. I want to have now the better room but she refuses.
+I am nothing compared to my brother.
+We are having a baby and my wife loves her job and makes more money than me. I want to be a stay at home dad but my wife has a problem with it.
+My GF and I are great together. She says she is serious about us but she doesn't let me meet her kids.
+My bf lost his job 5 months ago and he is over-emotional, controlling, and far-too-angry with me for littlest things. I know it is just a phase but I am getting tired of it.
+I am sick and feel horrible but my husband does not believe me, he thinks that I am pretending because I want attention and just need a break from everything.
+My BF told me that he no longer loves me but wants to stay together.
+I dated a guy 4 times and he disappeared. I met him in a party and asked why he didn't contact me. He said that he only 'breaks up' with girls if he dated them more than 5 times.
+All of the women that my BF dated before me are much hotter than me. It makes me feel insecure in our relationship.
+My rent went up and I don't make a lot of money. I asked my parents if I could live with them. They said no even though they have an extra room. 
+I love my girlfriend and I asked her to move in with my dog and me. She said yes to living with me but no to living with my dog.
+My wife is pregnant again and she is not sure if it is from a guy she hooked up with once at a workshop or from me.  I want to leave but without me she will have no money or support.
+We have an open relationship, which is what we both wanted but my partner has lots of lovers and I am having a hard time meeting people I like. I feel lonely when he goes out.
+My husband promised we would have a Christian home and he would go to church with me. Three months after the wedding he decided that he is not into it anymore
+My wife never texts or calls me when she travels for work.
+My partner never answers my emails. I feel like I am at the bottom of his priorities when he goes over his mail.
+My wife wants to have separate bank accounts after we get married and does not want me to have access to her account. TFU, right?
+I just found out that the woman I had been dating for five months has a kid. She never mentioned him. I really like her but I think it is a worming sign and I should leave her. 
+My boyfriend tolerates my kids but does not really love them. 
+My wife works a lot and does not want kids.  She is willing to have a kid for me but it feels wrong to have a baby as a 'favor' to me, knowing she herself does not want it.
+My girlfriend complains ALL the time.
+My partner wants us to buy two of everything: two iPads, two home computers, two cameras, etc. I think it is a waste of money and we should share some things.
+A guy I am dating never pays for me, not even on our first date or on my birthday.
+My wife makes plans for us every weekend and never checks if it works for me. I am always trapped in commitments she made to friends, her family or the kids.
+My husband moved our son to a new school without asking me. TFU!
+My boyfriend spends hundreds of dollars on me. I just found out that he is in a huge debt but when I said I don't want him to spend money on me he got upset.
+My boss and my coworker are both from Moscow and they speak Russian at work all day. I feel left out not just socially but from work information too.
+My wife is in charge of the dishes. She always cleans them up but sometimes two days after we had a meal. She says it is her chore and I should CTFO
+My husband wants to put 80% of our money in stocks and I feel that he is risking all of our savings 
+Everything I tell my sister she ends up sharing with other people in the family
+My brother in law is making fun of anything I do or say. My wife says that it is just his sense of humor
+My sister does not like my girlfriend.  We used to hang out a lot together but now she would see me only if it is without my GF.
+For the last 10 months my BF had been giving me hints that he is about to propose but he is not proposing.  I think he is going to leave me in this limbo forever
+My amazing BF wants to get married but he does not want to have kids. I really want kids.
+My husband is super sweet to me when we are with friends and family but when it is just the two of us at home he is busy all the time and does not pay attention to me.
+A guy in a club tried to forcefully kiss me when my boyfriend went to get a drink. I was upset and wanted to go home but my boyfriend said he is not done dancing and drinking 
+My boyfriend always offers everyone a drink in parties but never asks me or brings me a drink 
+My husband pays for dinners or lunches for women friends but never for his men friends
+My wife has something to say about any expense I make. Last week I got a really nice bike for a reasonable price and she said: do you really need it?
+My husband doesn't answer my texts and says that he is busy with work but I see him posting on FB all the time
+My wife sends me a text messages with explosive info and then does not check her phone and does not answer for hours. 
+I was hired to run a project but on the first day of work my boss said that I am not ready yet to lead a project. If he didn't think I am ready why did he hire me?
+We are a family of three and we only have two rooms. My partner wants all of us to sleep in one room so he can turn the second room into his office
+I took care of my boyfriend and supported him for 2 years after he had a bad accident. Now I found out that during this time he had an online affair.
+My boyfriend wants us to separate our laundry. He does not want my laundry to touch his. 
+My girlfriend is Jewish and she does not let me bring pork and shrimp into the house. I love pork
+My husband does not want my parents to help me with the baby; He said that he does not like their values. But I love my parents and need the help
+My wife has dinner meetings three times a week.
+My wife is pregnant and can't drink alcohol and coffee she wants me to stop drinking too out of solidarity. She thinks that we are 'pregnant' together.
+My BF says he loves me and I am the one for him but he does not want to leave his wife because of the kids. Should I CTFO or leave him? 
+My husband is British and he goes to happy hour in a local bar every day after work.  He says it is a cultural thing but I think he just does not want to help with the kids
+My mother in law is criticizing me all the time in front of the kids.
+My husband and I take turns cleaning and cooking but every time it is his turn he hires a cleaning service or orders food delivery from a local restaurant.
+My roommate is loud. When he speaks on the phone or have friends over I can't do anything. He says that he has a loud voice and can't really change it 
+I love my girlfriend but I can't stand her smell. I asked her to change her soap and body lotion but it didn't help
+I met a really nice girl. She is perfect but I can't stand her voice 
+My wife started snoring. Such a turn off
+My gorgeous girlfriend says she loves me but I think she stays with me just for my money.
+My roommate eats with his mouth open. I am avoiding having meals with him but now he started noticing it and thinks I don't like him 
+I am dating a sweet guy. I like him but can't stand his friends
+My boyfriend found a new group of friends. They get high and have sex parties.  I am really worried about him
+My girlfriend has a car and I don't but I am afraid driving with her. When she drives she looks at her phone to answer texts and emails. If I say something she gets upset
+My girlfriend hates my family.
+My wife shouts all the time, she says she is not shouting and that's just how she talks
+My boyfriend's parents promised him a new car if he would leave me. So he did. Now he wants to get back together. I upset but I love him. Should I CTFO and go back to him?
+My GF is not open to anything in bed. She is stunning and smart but sex is boring! 
+My parents make a lot of money.  Like $400,000 or more a year. They paid for my college, but now won't help me financially with anything 
+I went to a party with my step brother when he visited and we got drunk and had sex.  Now I feel uncomfortable to come to the family Thanksgiving gathering
+My BF will not show me pictures of his ex girlfriends
+My brother drinks and drive. I asked my wife not to give him anything to drink when he comes over but she says he is not a baby and she is not going to monitor him
+I broke up with my GF and she asked to stay in my place until she will find a new apartment. I was ok with it but now she wants me not to date until she leaves
+My BF wants to film me in intimate positions. He says it turns him on and gets upset when I say no.
+My husband is a professor and I am unemployed. I just got a job in another university and they are offering him a job too. I want to move, but he says it is better for one of us to be in a good university than both in a mediocre one
+My BF admits to thinking about other women when we have sex. TFU, right?
+My ex left me and I cannot get over her. Now my friend wants to date her
+My husband want us to go to his ex wife's family for Thanksgiving
+A few months ago I had sex for a few weeks with a girl and she said she is on the pill. She left.  Yesterday I saw her in the street and she was pregnant. I am afraid she tricked me
+My BF will only have sex with me with his shirt on. It kills the intimacy
+Wife had breast implants surgery when I was away without telling me
+I am comfortable with my weight but my husband wants me to go on a diet and exercise
+Everyone thinks I am gay but I am not
+Changed my major from Economics to Philosophy and now my parents don't want to pay for my colleague.
+My boss wants to friend me on facebook. TFU, no?
+I just got married and my husband will not wear his ring
+I am short and people often treat me like I am a little girl
+None of my friends remember my birthday
+My BF wants his ex to marry us
+I asked my GF to marry me and she said we are too young (22). I feel rejected. Should I leave her or CTFO and wait?
+My friends stopped contacting me and I am not sure why
+My BF is a student and has the summer off. He is traveling with another girl to Europe for a month. He says she is a good friend for traveling but I am uncomfortable with it
+My friend invited me to be her bridesmaid but said I can not come with my husband because it is a really small wedding
+My ex-husband comes into my house when I am not home to "be with the kids." I asked that he will see him in his place or go out with them but he ignores me
+My GF wants us to pretend that we are roommates and not lovers when her parents are in town
+My BF is really aggressive to his kids but nice and gentle with me
+I love my BF but I am always feel anxious and unhappy when we are together
+A girl on our first date: "I hurt everyone I'm close to, maybe you should just save yourself"
+I caught my coworker checking my emails on my desktop
+My BF sent his friends a picture of me naked
+My GF said to her girlfriend on the phone that she would date the new hot HR manager if she was not with me. I feel betrayed and don't really understand what it means
+My BF and I get along great but he never gives me compliments or say anything nice about me
+One year together and he never said "I love you"
+I caught my wife discussing our marriage with another man online
+I have a great job and my boyfriend is unemployed. I pay the bills when we go out but it still bugs me that he never offer to pay for anything.
+My partner lost her job. I am ok with paying for everything but I feel she is taking advantage of it and is being very picky about jobs
+I had a one night stand many years ago. Nothing since then. But my wife still doesn't fully trust me
+I need more alone time,  but every time I say that my partner takes it as rejection.
+My girlfriend turns any tiniest disagreement into an all-out war.  I feel like I am constantly walking on eggshells.
+The minute we moved in together my boyfriend started treating me like a roommate.  No romance, no sparkle.
+My wife is not interested in doing anything besides being with our baby. I try to tell her that we are not only parents but also a couple but she doesn't get it.
+My wife does not care about how she looks. She gained weight and goes with big clothes. It is as if she isn't interested at all in being sexy
+I am dating a great guy. One problem: he thinks he is cool but his clothes are ridiculous and weird. I don't like to be seen with him in public.
+My girlfriend wants to go shopping with me for new clothes,  she wants me also to change my haircut, etc. I want her to like me but I am annoyed that she can't like me the way I am.
+The girl I am dating thinks I am a loser because the house I own is not big enough
+My husband works all the time. He doesn't even make that much money. He just likes to work.
+I love cooking but my wife hates my food
+My boyfriend wants his ex to move in with us for three months because she lost her lease and can't finds a new place.  TFU!
+My husband is too honest with me and I can't take it.  His honesty hurts me. Last night he said: you are not so pretty anymore but I still love you
+My husband does not trust any babysitter we interview. I think he just does not want to go out
+My girlfriend hates kissing
+My boyfriend never hugs me in public
+My fiancé does not want to change her relationship status on facebook
+I have been with my BF for 6 years and we still don't even live together
+I am dating an older guy who is almost 45 and was never married. Is that a red flag?
+A married guy I met at concert three months ago texts and chats with me a few times a day and I think he likes me but he does not ask me out.
+My married brother thinks that it is ok if he has sex with other people as long as he makes sure his partner wouldn't find out but I think TFU
+My boyfriend tried to convince me to have a threesome and when I agreed he paid attention to the other woman and barely looked at me.

--- a/convert_cards.cc
+++ b/convert_cards.cc
@@ -71,7 +71,7 @@ int main(int argc, char** argv) {
       } while (cids.find(cid) != cids.end());
       cids.insert(cid);
 
-      Card c(cid, text, CARD_COLORS[static_cast<uint64_t>(cid) % CARD_COLORS.size()]);
+      Card c(cid, text, CARD_COLORS[(static_cast<uint64_t>(cid) * 17) % CARD_COLORS.size()]);
       if (std::isdigit(text[0]) && text[1] == '\t') {
         const int index = static_cast<double>(text[0] - '0');
         c.text = text.substr(2);

--- a/server.cc
+++ b/server.cc
@@ -31,7 +31,6 @@ using namespace CTFO;
 
 DEFINE_string(cards_file, "cards.json", "Cards data file in JSON format.");
 DEFINE_int32(port, 8383, "Port to spawn CTFO RESTful server on.");
-DEFINE_int32(healthz_port, 8393, "Port to spawn /healthz to return OK.");
 DEFINE_string(storage_file, "./db.json", "The file to store the snapshot of the database in.");
 DEFINE_int32(event_log_port, 0, "Port to spawn event collector on.");  // 0 = the same as `port`.
 DEFINE_string(event_log_file,
@@ -46,7 +45,6 @@ int main(int argc, char **argv) {
   bricks::random::SetSeed(FLAGS_rand_seed);
   CTFOServer(FLAGS_cards_file,
              FLAGS_port,
-             FLAGS_healthz_port,
              FLAGS_storage_file,
              FLAGS_event_log_port,
              FLAGS_event_log_file,

--- a/server.h
+++ b/server.h
@@ -1395,7 +1395,7 @@ class CTFOServer final {
       }
     } catch (const std::bad_cast&) {
       // `event` is not an `iOSGenericEvent`.
-      DebugPrint("[UpdateStateOnEvent] Not an `iOSGenericEvent`.");
+      DebugPrint("[UpdateStateOnEvent] Not an `iOSGenericEvent`: " + JSON(event));
     }
   }
 };

--- a/server.h
+++ b/server.h
@@ -109,14 +109,12 @@ class CTFOServer final {
  public:
   explicit CTFOServer(const std::string& cards_file,
                       int port,
-                      int healthz_port,
                       const std::string& storage_file,
                       int event_log_port,
                       const std::string& event_log_file,
                       const bricks::time::MILLISECONDS_INTERVAL tick_interval_ms,
                       const bool debug_print_to_stderr = false)
       : port_(port),
-        healthz_port_(healthz_port),
         event_log_file_(event_log_file),
         event_collector_(event_log_port ? event_log_port : port,
                          event_log_stream_,
@@ -129,13 +127,22 @@ class CTFOServer final {
     event_log_stream_.open(event_log_file_, std::ofstream::out | std::ofstream::app);
 
     bricks::cerealize::CerealFileParser<Card, bricks::cerealize::CerealFormat::JSON> cf(cards_file);
+    const UID admin_uid = static_cast<UID>(1000000000000000001ull);
     storage_.Transaction([&cf](StorageAPI::T_DATA data) {
-      while (cf.Next([&data](const Card& card) { data.cards.Insert(card); })) {
+      User admin_user;
+      admin_user.uid = admin_uid;
+      admin_user.level = 80;         // Superuser 80lvl.
+      admin_user.score = 999999999;  // With one short to one billion points.
+      data.users.Insert(admin_user);
+      while (cf.Next([&data](const Card& card) {
+          data.cards.Insert(card);
+          data.card_authors.Add(CardAuthor{card.cid, admin_uid});
+        })) {
         ;
       }
     }).Go();
 
-    HTTP(healthz_port_).Register("/healthz", [](Request r) { r("OK\n"); });
+    HTTP(port_).Register("/healthz", [](Request r) { r("OK\n"); });
     HTTP(port_).Register("/ctfo/auth/ios", BindToThis(&CTFOServer::RouteAuthiOS));
     HTTP(port_).Register("/ctfo/feed", BindToThis(&CTFOServer::RouteFeed));
     HTTP(port_).Register("/ctfo/favs", BindToThis(&CTFOServer::RouteFavorites));
@@ -147,7 +154,7 @@ class CTFOServer final {
 
   ~CTFOServer() {
     // TODO(dkorolev): Scoped registerers FTW.
-    HTTP(healthz_port_).UnRegister("/healthz");
+    HTTP(port_).UnRegister("/healthz");
     HTTP(port_).UnRegister("/ctfo/auth/ios");
     HTTP(port_).UnRegister("/ctfo/feed");
     HTTP(port_).UnRegister("/ctfo/favs");
@@ -376,10 +383,11 @@ class CTFOServer final {
                     if (Exists(comments_per_card)) {
                       card_entry.number_of_comments = Value(comments_per_card).Size();
                     }
+                    const auto now = static_cast<uint64_t>(bricks::time::Now());
                     card_entry.text = card.text;
                     card_entry.ms = card.ms;
                     card_entry.color = card.color;
-                    card_entry.relevance = RandomDouble(0, 1);
+                    card_entry.relevance = 0.9 * std::pow(0.99, (now - card.ms) * (1.0 / (1000 * 60 * 60 * 24)));
                     card_entry.ctfo_score = 50u;
                     card_entry.tfu_score = 50u;
                     card_entry.ctfo_count = card.ctfo_count;
@@ -493,10 +501,11 @@ class CTFOServer final {
                     if (Exists(comments_iterator)) {
                       card_entry.number_of_comments = Value(comments_iterator).Size();
                     }
+                    const auto now = static_cast<uint64_t>(bricks::time::Now());
                     card_entry.text = card.text;
                     card_entry.ms = card.ms;
                     card_entry.color = card.color;
-                    card_entry.relevance = RandomDouble(0, 1);
+                    card_entry.relevance = 0.9 * std::pow(0.99, (now - card.ms) * (1.0 / (1000 * 60 * 60 * 24)));
                     card_entry.ctfo_score = 50u;
                     card_entry.tfu_score = 50u;
                     card_entry.ctfo_count = card.ctfo_count;
@@ -581,7 +590,7 @@ class CTFOServer final {
             card_entry.text = card.text;
             card_entry.ms = card.ms;
             card_entry.color = card.color;
-            card_entry.relevance = RandomDouble(0, 1);
+            card_entry.relevance = 1.0;  // When `GET`-ting a card, make it 1.0.
             card_entry.ctfo_score = 50u;
             card_entry.tfu_score = 50u;
             card_entry.ctfo_count = card.ctfo_count;
@@ -1015,7 +1024,6 @@ class CTFOServer final {
 
  private:
   const int port_;
-  const int healthz_port_;
   const std::string event_log_file_;
   std::ofstream event_log_stream_;
   EventCollectorHTTPServer event_collector_;
@@ -1114,7 +1122,7 @@ class CTFOServer final {
           card_entry.text = card.text;
           card_entry.ms = card.ms;
           card_entry.color = card.color;
-          card_entry.relevance = RandomDouble(0, 1);
+          card_entry.relevance = 0.0;  // Will be overridden later.
           card_entry.ctfo_score = 50u;
           card_entry.tfu_score = 50u;
           card_entry.ctfo_count = card.ctfo_count;

--- a/test.cc
+++ b/test.cc
@@ -421,7 +421,7 @@ TEST(CTFO, SmokeTest) {
       EXPECT_EQ("Foo.", feed_recent[0].text);
       EXPECT_TRUE(feed_recent[0].is_my_card);
       EXPECT_EQ(0u, feed_recent[0].number_of_comments);
-      EXPECT_EQ(1.0, feed_recent[0].relevance);
+      EXPECT_DOUBLE_EQ(0.9, feed_recent[0].relevance);
     }
 
     {
@@ -438,7 +438,7 @@ TEST(CTFO, SmokeTest) {
       EXPECT_EQ("Foo.", feed_recent[0].text);
       EXPECT_TRUE(feed_recent[0].is_my_card);
       EXPECT_EQ(0u, feed_recent[0].number_of_comments);
-      EXPECT_DOUBLE_EQ(0.99, feed_recent[0].relevance);
+      EXPECT_DOUBLE_EQ(0.9 * 0.99, feed_recent[0].relevance);
     }
 
     {
@@ -455,7 +455,7 @@ TEST(CTFO, SmokeTest) {
       EXPECT_EQ("Foo.", feed_recent[0].text);
       EXPECT_TRUE(feed_recent[0].is_my_card);
       EXPECT_EQ(0u, feed_recent[0].number_of_comments);
-      EXPECT_DOUBLE_EQ(0.99 * 0.99, feed_recent[0].relevance);
+      EXPECT_DOUBLE_EQ(0.9 * 0.99 * 0.99, feed_recent[0].relevance);
     }
 
     // Restore the time back.


### PR DESCRIPTION
Hi @mzhurovich 

Should be good to go modulo the last remaining notifications.

All tests pass upon re-generating `cards.json` using `./.current/convert_cards` with the top five lines of `cards.txt` removed (otherwise the starting cards return atop the real ones, even the user-added ones).

Pushing `cards.txt` into the repo blessed by GL.

Thanks,
Dima
