### PR TITLE
REST builds.

### DIFF
--- a/convert_old_db/convert.cc
+++ b/convert_old_db/convert.cc
@@ -127,7 +127,9 @@ std::string NotificationsUpdate(const std::chrono::microseconds timestamp,
   transaction.meta.timestamp = timestamp;
 
   new_ctfo::Notification notification;
-  notification.timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(timestamp);
+  // Just to make REST compile wrt `{To/From}String()` -- D.K.
+  // notification.timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(timestamp);
+  notification.timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(timestamp).count();
 
   std::regex mega_regex(
       ".*\"uid\":([0-9]+).*\"polymorphic_name\":\"([a-zA-Z]+)\".*\"data\":(\\{[^\\}]+\\})[\\}]+");

--- a/convert_old_db/gen_golden_db.cc
+++ b/convert_old_db/gen_golden_db.cc
@@ -71,7 +71,9 @@ int main(int argc, char** argv) {
       new_ctfo::Notification notification;
       new_ctfo::NotificationMyCardNewComment new_comment;
       notification.uid = static_cast<UID>(42);
-      notification.timestamp = std::chrono::milliseconds(100);
+      // Just to have REST build, wrt `{To/From}String`. -- D.K.
+      // notification.timestamp = std::chrono::milliseconds(100);
+      notification.timestamp = 100ull;
       notification.notification = new_comment;
       fields.notification.Add(notification);
     }).Go();

--- a/convert_old_db/new_schema.h
+++ b/convert_old_db/new_schema.h
@@ -79,6 +79,15 @@ CURRENT_STRUCT(AuthKey) {
   // TODO(dkorolev): Revisit this. For now, I just assume all `key`-s are distinct.
   size_t Hash() const { return std::hash<std::string>()(key); }
   bool operator==(const AuthKey& rhs) const { return key == rhs.key && type == rhs.type; }
+
+  const std::string& ToString() const {
+    return key;
+  }
+
+  void FromString(const std::string& s) {
+    key = s;
+    type = AUTH_TYPE::UNDEFINED;  // TODO(dkorolev): Wrong, just to have this REST compile. -- D.K.
+  }
 };
 
 CURRENT_STRUCT(AuthKeyTokenPair) {
@@ -108,7 +117,8 @@ CURRENT_STRUCT(AuthKeyUIDPair) {
 CURRENT_STRUCT(Card) {
   CURRENT_FIELD(cid, CID, CID::INVALID_CARD);
   CURRENT_USE_FIELD_AS_KEY(cid);
-  CURRENT_FIELD(ms, std::chrono::milliseconds, 0);
+  // CURRENT_FIELD(ms, std::chrono::milliseconds, 0);
+  CURRENT_FIELD(ms, uint64_t, 0);  // To have REST compile, `{To/From}String`. -- D.K.
   CURRENT_FIELD(text, std::string);
   CURRENT_FIELD(color, Color);
   CURRENT_FIELD(ctfo_count, uint32_t, 0u);    // Number of users, who said "CTFO" on this card.
@@ -374,7 +384,8 @@ using T_NOTIFICATIONS_VARIANT = Variant<NotificationMyCardNewComment,
 CURRENT_STRUCT(Notification) {
   CURRENT_FIELD(uid, UID, UID::INVALID_USER);
   CURRENT_USE_FIELD_AS_ROW(uid);
-  CURRENT_FIELD(timestamp, std::chrono::milliseconds);
+  // CURRENT_FIELD(timestamp, std::chrono::milliseconds);
+  CURRENT_FIELD(timestamp, uint64_t, 0);  // To have REST compile, `{To/From}String`. -- D.K.
   CURRENT_USE_FIELD_AS_COL(timestamp);
   CURRENT_FIELD(notification, T_NOTIFICATIONS_VARIANT);
 };


### PR DESCRIPTION
Hi @mzhurovich ,

Here's REST for CTFO, which builds with https://github.com/c5t/Current/pull/421 applied.

Note: Minor schema change (`std::chrono::{milli/micro}seconds` are not `{To/From}String`-serializable, and I converted those into `uint64_t`-s), would need to re-run `./.current/convert`.

In other news, JSONView in Chrome really, really, doesn't do a good job with full precision `uint64`-s. It rounds them, leaving the last three digits zeroes. Something to think of.

Thanks,
Dima
