### PR TITLE
https://ctfoapp.current.ai prod.

### DIFF
--- a/server.cc
+++ b/server.cc
@@ -23,6 +23,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 *******************************************************************************/
 
+// Enable "$REST/data/user?export" unconditionally.
+#define CURRENT_ALLOW_STORAGE_EXPORT_FROM_MASTER
+
 #include "server.h"
 
 #include "../Current/Bricks/dflags/dflags.h"

--- a/server.cc
+++ b/server.cc
@@ -37,7 +37,9 @@ DEFINE_string(midichlorians_file,
               "./ctfo_events.log",
               "Log file to store events received by midichlorians server");
 DEFINE_int32(rest_port, 8384, "Port to spawn RESTful server on.");  // 0 = the same as `port`.
-DEFINE_string(rest_url_prefix, "http://localhost", "Hypermedia route prefix to spawn RESTful server on.");
+DEFINE_string(rest_url_prefix,
+              "http://localhost:8384/ctfo/rest",
+              "Hypermedia route prefix to spawn RESTful server on.");
 DEFINE_int32(rand_seed, 42, "The answer to the question of life, universe and everything.");
 DEFINE_int32(tick_interval_ms, 5 * 60 * 1000, "Maximum interval between event entries.");
 DEFINE_bool(debug_print, true, "Print debug info to stderr.");

--- a/server.h
+++ b/server.h
@@ -128,10 +128,7 @@ class CTFOServer final {
             params.GetMidichloriansPort(), *this, params.tick_interval_ms, "/ctfo/log", "OK\n"),
         debug_print_(params.debug_print_to_stderr),
         storage_(params.storage_file),
-        rest_(storage_,
-              params.GetRESTPort(),
-              "/ctfo/rest",
-              params.rest_url_prefix + ':' + current::ToString(params.GetRESTPort()) + "/ctfo/rest") {
+        rest_(storage_, params.GetRESTPort(), "/ctfo/rest", params.rest_url_prefix) {
     midichlorians_stream_.open(params.midichlorians_file, std::ofstream::out | std::ofstream::app);
 
 #ifdef MUST_IMPORT_INITIAL_CTFO_CARDS


### PR DESCRIPTION
Hi @grixa @mzhurovich !

Minor tweak while going prod: Don't add local port for hypermedia prefix URL. It's behind `ELB`  + `nginx` after all. :-)

Thanks,
Dima

PS: The prod depends on the following three minor changed in Current now:
- https://github.com/C5T/Current/commit/8842cc8a4e419adf0d940c40c36883b4a48a1cbb
- https://github.com/C5T/Current/commit/d0a3eba943f1b2e3dcbdf082fd0525e523628b0b
- https://github.com/C5T/Current/commit/c463fb1a8b406730073dec962e75519b393bb90d

We'll get there shortly.
