### PR TITLE
Flagging a card removes it from "My favorites".

### DIFF
--- a/schema.h
+++ b/schema.h
@@ -532,7 +532,8 @@ CURRENT_STRUCT(Notification) {
   ResponseNotification BuildResponseNotification() const {
     ResponseNotificationBuilder builder;
     builder.response.ms = std::chrono::duration_cast<std::chrono::milliseconds>(timestamp);
-    builder.response.nid = NIDToString(static_cast<NID>(ID_RANGE * 5 + timestamp.count()));
+    // To play it safe, let's leave notification IDs full range for now. They are only used as strings. -- D.K.
+    builder.response.nid = NIDToString(static_cast<NID>(OLD_ID_RANGE * 5 + timestamp.count()));
     notification.Call(builder);
     return builder.response;
   }

--- a/server.h
+++ b/server.h
@@ -374,13 +374,16 @@ class CTFOServer final {
               CopyUserInfoToResponseEntry(Value(user), Exists(data.banned_user[uid]), rfavs.user);
 
               const auto& answers = data.answer;
+              const auto& flagged_cards = data.flagged_card;
 
               // Get favs.
               std::vector<std::pair<std::chrono::microseconds, CID>> favs;
               const auto& favorites = data.favorite;
               for (const auto& fav : favorites.Row(uid)) {
                 if (fav.favorited) {
-                  favs.emplace_back(fav.us, fav.cid);
+                  if (!Exists(flagged_cards.Get(fav.cid, uid))) {
+                    favs.emplace_back(fav.us, fav.cid);
+                  }
                 }
               }
 

--- a/test.cc
+++ b/test.cc
@@ -1250,7 +1250,7 @@ TEST(CTFO, SmokeTest) {
       EXPECT_EQ(comment_to_be_notified_about_oid, feed_response.notifications[0].oid);
       EXPECT_EQ("Ding!", feed_response.notifications[0].text);
       EXPECT_EQ(1u, feed_response.notifications[0].n);
-      EXPECT_EQ("n05000000000600003000", feed_response.notifications[0].nid);
+      EXPECT_EQ("n00005000000600003000", feed_response.notifications[0].nid);
       EXPECT_EQ(600003u, feed_response.notifications[0].ms.count());
     }
     // Delete that comment.
@@ -1426,7 +1426,7 @@ TEST(CTFO, NotificationsSerializeWell) {
       me, std::chrono::microseconds(12345000ull), NotificationMyCardNewComment(uid, cid, oid, "foo"));
   const std::string user_facing_json = JSON<JSONFormat::Minimalistic>(notification.BuildResponseNotification());
   EXPECT_EQ(
-      "{\"nid\":\"n05000000000012345000\",\"type\":\"MyCardNewComment\",\"ms\":12345,\"uid\":"
+      "{\"nid\":\"n00005000000012345000\",\"type\":\"MyCardNewComment\",\"ms\":12345,\"uid\":"
       "\"u00000000000000000001\",\"cid\":\"c00000000000000000002\",\"oid\":\"o00000000000000000003\",\"text\":"
       "\"foo\",\"card\":{\"cid\":\"cINVALID\",\"author_uid\":\"uINVALID\",\"text\":\"\",\"ms\":0,"
       "\"color\":{\"red\":0,\"green\":0,\"blue\":0},\"relevance\":0.0,\"ctfo_score\":0,\"tfu_score\":0,\"ctfo_"

--- a/test.cc
+++ b/test.cc
@@ -1250,7 +1250,7 @@ TEST(CTFO, SmokeTest) {
       EXPECT_EQ(comment_to_be_notified_about_oid, feed_response.notifications[0].oid);
       EXPECT_EQ("Ding!", feed_response.notifications[0].text);
       EXPECT_EQ(1u, feed_response.notifications[0].n);
-      EXPECT_EQ("n00005000000600003000", feed_response.notifications[0].nid);
+      EXPECT_EQ("n05000000000600003000", feed_response.notifications[0].nid);
       EXPECT_EQ(600003u, feed_response.notifications[0].ms.count());
     }
     // Delete that comment.
@@ -1468,7 +1468,7 @@ TEST(CTFO, NotificationsSerializeWell) {
       me, std::chrono::microseconds(12345000ull), NotificationMyCardNewComment(uid, cid, oid, "foo"));
   const std::string user_facing_json = JSON<JSONFormat::Minimalistic>(notification.BuildResponseNotification());
   EXPECT_EQ(
-      "{\"nid\":\"n00005000000012345000\",\"type\":\"MyCardNewComment\",\"ms\":12345,\"uid\":"
+      "{\"nid\":\"n05000000000012345000\",\"type\":\"MyCardNewComment\",\"ms\":12345,\"uid\":"
       "\"u00000000000000000001\",\"cid\":\"c00000000000000000002\",\"oid\":\"o00000000000000000003\",\"text\":"
       "\"foo\",\"card\":{\"cid\":\"cINVALID\",\"author_uid\":\"uINVALID\",\"text\":\"\",\"ms\":0,"
       "\"color\":{\"red\":0,\"green\":0,\"blue\":0},\"relevance\":0.0,\"ctfo_score\":0,\"tfu_score\":0,\"ctfo_"


### PR DESCRIPTION
I also figured we can keep full-range IDs for notifications (`"NID"`) for now. The app only uses them as strings, so we should be fine.
